### PR TITLE
feat: add user display name resolution and CLI auth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ The authentication flow allows you to obtain and refresh Google API tokens, whic
 
 ## Requirements
 
-- Python 3.8+
-- Google Cloud project with Chat API enabled
+- Python 3.13+
+- Google Cloud project with the following APIs enabled:
+  - Google Chat API
+  - People API (for user display names)
 - OAuth2 credentials from Google Cloud Console
 
 # How to use?
@@ -50,14 +52,30 @@ Authorized redirect URIs: `http://localhost:8000/auth/callback`
 5. After you create a OAuth 2.0 Client, download the client secrets as `.json` file. Save as `credentials.json` at top level of project.
 
 
-## Run Auth server and get your Google access token (login google only, not MCP server yet)
+## Authentication
+
+There are two authentication modes available:
+
+### Option 1: CLI Mode (Recommended for headless/remote environments)
+```bash
+uv run python server.py --auth cli
 ```
-python server.py -local-auth --port 8000
+
+This will:
+1. Display an authorization URL
+2. Open the URL in any browser (can be on another device)
+3. Complete Google authorization
+4. Copy the redirect URL from browser and paste it back to terminal
+5. Token will be saved as `token.json`
+
+### Option 2: Web Mode (For environments with local browser)
+```bash
+uv run python server.py --auth web --port 8000
 ```
 
 - Open browser at http://localhost:8000/auth
-- login it!
-- after loggined, you access token will be saved as `token.json`
+- Complete Google login
+- Token will be saved as `token.json`
 
 ## MCP Configuration (mcp.json)
 ```
@@ -96,11 +114,18 @@ podman run -it --rm \
 
 ### Run Auth Server in Container
 ```bash
+# Web mode
 docker run -it --rm \
   -p 8000:8000 \
   -v /path/to/your/project:/data \
   ghcr.io/chy168/google-chat-mcp-server:latest \
-  -local-auth --host 0.0.0.0 --port 8000 --token-path=/data/token.json
+  --auth web --host 0.0.0.0 --port 8000 --token-path=/data/token.json
+
+# CLI mode (for headless environments)
+docker run -it --rm \
+  -v /path/to/your/project:/data \
+  ghcr.io/chy168/google-chat-mcp-server:latest \
+  --auth cli --token-path=/data/token.json
 ```
 
 

--- a/auth_cli.py
+++ b/auth_cli.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""CLI-based OAuth authentication for headless environments.
+
+Usage:
+    python auth_cli.py
+    # or via server.py:
+    python server.py --auth cli
+
+This script will:
+1. Display an authorization URL
+2. Wait for you to paste the authorization code
+3. Exchange the code for credentials and save them
+"""
+
+import os
+# Relax scope check - Google may return additional scopes that were previously granted
+os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE'] = '1'
+
+from pathlib import Path
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+from google_chat import (
+    get_credentials,
+    save_credentials,
+    SCOPES,
+    token_info
+)
+
+
+def run_cli_auth(credentials_path: str = 'credentials.json'):
+    """Run OAuth authentication via CLI (for headless environments)."""
+
+    # Check if we already have valid credentials
+    creds = get_credentials()
+    if creds:
+        print("Valid credentials already exist.")
+        print(f"Token file: {token_info['token_path']}")
+        return
+
+    # Check for credentials.json
+    creds_file = Path(credentials_path)
+    if not creds_file.exists():
+        print(f"ERROR: {credentials_path} not found.")
+        print("Please download it from Google Cloud Console and save it in the current directory.")
+        return
+
+    # Use OOB-style redirect for manual code entry
+    # Since Google deprecated OOB, we use localhost but handle it manually
+    flow = InstalledAppFlow.from_client_secrets_file(
+        str(creds_file),
+        SCOPES,
+        redirect_uri='http://localhost:8000/auth/callback'
+    )
+
+    # Generate authorization URL
+    auth_url, _ = flow.authorization_url(
+        access_type='offline',
+        prompt='consent',
+        include_granted_scopes='true'
+    )
+
+    print("\n" + "=" * 60)
+    print("AUTHORIZATION REQUIRED")
+    print("=" * 60)
+    print("\n1. Open this URL in a browser (can be on another device):\n")
+    print(f"   {auth_url}\n")
+    print("2. Complete the authorization flow")
+    print("3. You will be redirected to a localhost URL that may fail to load")
+    print("4. Copy the FULL URL from your browser's address bar")
+    print("   (It will look like: http://localhost:8000/auth/callback?code=...&scope=...)")
+    print("\n" + "=" * 60)
+
+    # Get the redirect URL from user
+    redirect_url = input("\nPaste the full redirect URL here: ").strip()
+
+    if not redirect_url:
+        print("ERROR: No URL provided.")
+        return
+
+    try:
+        # Extract the authorization code from the URL
+        from urllib.parse import urlparse, parse_qs
+        parsed = urlparse(redirect_url)
+        params = parse_qs(parsed.query)
+
+        if 'error' in params:
+            print(f"ERROR: Authorization failed: {params['error'][0]}")
+            return
+
+        if 'code' not in params:
+            print("ERROR: No authorization code found in URL.")
+            print("Make sure you copied the complete URL including the ?code=... part")
+            return
+
+        code = params['code'][0]
+
+        # Exchange the code for credentials
+        print("\nExchanging authorization code for credentials...")
+        flow.fetch_token(code=code)
+        creds = flow.credentials
+
+        if not creds.refresh_token:
+            print("WARNING: No refresh token received. You may need to re-authorize later.")
+
+        # Save credentials
+        save_credentials(creds)
+
+        print("\n" + "=" * 60)
+        print("SUCCESS!")
+        print("=" * 60)
+        print(f"Token saved to: {token_info['token_path']}")
+        print(f"Expires at: {creds.expiry.isoformat() if creds.expiry else 'N/A'}")
+        print(f"Has refresh token: {bool(creds.refresh_token)}")
+
+    except Exception as e:
+        print(f"\nERROR: Failed to complete authorization: {e}")
+
+
+if __name__ == "__main__":
+    run_cli_auth()

--- a/server.py
+++ b/server.py
@@ -7,6 +7,7 @@ from typing import List, Dict
 from fastmcp import FastMCP
 from google_chat import list_chat_spaces, DEFAULT_CALLBACK_URL, set_token_path, set_save_token_mode
 from server_auth import run_auth_server
+from auth_cli import run_cli_auth
 
 # Create an MCP server
 mcp = FastMCP("Demo")
@@ -105,22 +106,23 @@ async def get_space_messages(space_name: str,
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='MCP Server with Google Chat Authentication')
-    parser.add_argument('-local-auth', action='store_true', help='Run the local authentication server')
-    parser.add_argument('--host', default='localhost', help='Host to bind the server to (default: localhost)')
-    parser.add_argument('--port', type=int, default=8000, help='Port to run the server on (default: 8000)')
+    parser.add_argument('--auth', choices=['web', 'cli'],
+                        help='Run OAuth authentication (web: browser-based, cli: headless/terminal)')
+    parser.add_argument('--host', default='localhost', help='Host to bind the auth server to (default: localhost)')
+    parser.add_argument('--port', type=int, default=8000, help='Port to run the auth server on (default: 8000)')
     parser.add_argument('--token-path', default='token.json', help='Path to store OAuth token (default: token.json)')
     parser.add_argument('--disable-token-saving', action='store_false', help='Disable token saving mode (enabled by default)')
-    
+
     args = parser.parse_args()
-    
+
     # Set the token path for OAuth storage
     set_token_path(args.token_path)
-    
+
     # Set message filtering
     set_save_token_mode(args.disable_token_saving)
-    
-    if args.local_auth:
-        print(f"\nStarting local authentication server at http://{args.host}:{args.port}")
+
+    if args.auth == 'web':
+        print(f"\nStarting OAuth authentication server at http://{args.host}:{args.port}")
         print("Available endpoints:")
         print("  - /auth   : Start OAuth authentication flow")
         print("  - /status : Check authentication status")
@@ -130,5 +132,7 @@ if __name__ == "__main__":
         print("\nPress CTRL+C to stop the server")
         print("-" * 50)
         run_auth_server(port=args.port, host=args.host)
+    elif args.auth == 'cli':
+        run_cli_auth()
     else:
         mcp.run()


### PR DESCRIPTION
## Summary
- Add People API integration to resolve user display names in message search results
- Add CLI authentication mode (`--auth cli`) for headless/remote environments
- Update auth parameter from `-local-auth` to `--auth` (web/cli)
- Add user display name caching to reduce API calls
- Handle BOT senders with fallback display format (`Bot (short_id)`)
- Update README with new authentication options

## Changes
| File | Description |
|------|-------------|
| `google_chat.py` | Add People API scope, `get_user_display_name()` function, user name cache |
| `auth_cli.py` | New CLI authentication for headless environments |
| `server.py` | Add `--auth` parameter (web/cli modes) |
| `README.md` | Update authentication documentation |

## Test plan
- [ ] Test CLI auth mode: `uv run python server.py --auth cli`
- [ ] Test web auth mode: `uv run python server.py --auth web`
- [ ] Verify HUMAN sender shows display name
- [ ] Verify BOT sender shows `Bot (short_id)` format
- [ ] Enable People API in GCP project before testing